### PR TITLE
Load grade data in admins page

### DIFF
--- a/frontend/src/main/components/Jobs/JobComingSoon.js
+++ b/frontend/src/main/components/Jobs/JobComingSoon.js
@@ -1,5 +1,0 @@
-function JobComingSoon() {
-  return <p>Coming Soon! (The form for this job has not yet been created)</p>;
-}
-
-export default JobComingSoon;

--- a/frontend/src/main/components/Jobs/UploadGradesJobForm.js
+++ b/frontend/src/main/components/Jobs/UploadGradesJobForm.js
@@ -1,0 +1,37 @@
+// function UploadGradesJobForm() {
+//   return <p>In progress! (The form for this job has not yet been created)</p>;
+// }
+import { Form, Button, Container, Row, Col } from "react-bootstrap";
+// import { useForm } from "react-hook-form";
+
+function UploadGradesJobForm() {
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    // callback({});
+  };
+
+  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
+  const padding = { paddingTop: 10, paddingBottom: 10 };
+  // Stryker restore all
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Container>
+        <Row style={padding}>
+          <Col md="auto">
+            <Button
+              variant="primary"
+              type="submit"
+              data-testid="uploadGrades"
+            >
+              Update Grades
+            </Button>
+          </Col>
+        </Row>
+      </Container>
+    </Form>
+  );
+};
+
+export default UploadGradesJobForm;

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -4,7 +4,7 @@ import JobsTable from "main/components/Jobs/JobsTable";
 import { useBackend } from "main/utils/useBackend";
 import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
-import JobComingSoon from "main/components/Jobs/JobComingSoon";
+import UploadGradesJobForm from "main/components/Jobs/UploadGradesJobForm";
 
 import { useBackendMutation } from "main/utils/useBackend";
 import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
@@ -48,6 +48,11 @@ const AdminJobsPage = () => {
     method: "POST",
   });
 
+  const objectToAxiosParamsUploadGradesJob = () => ({
+    url: `/api/jobs/launch/uploadGradeData`,
+    method: "POST",
+  });
+
   // Stryker disable all
   const updateCoursesJobMutation = useBackendMutation(
     objectToAxiosParamsUpdateCoursesJob,
@@ -65,6 +70,12 @@ const AdminJobsPage = () => {
     {},
     ["/api/jobs/all"],
   );
+
+  const uploadGradesJobMutation = useBackendMutation(
+    objectToAxiosParamsUploadGradesJob,
+    {},
+    ["/api/jobs/all"],
+  );
   // Stryker restore all
 
   const submitUpdateCoursesJob = async (data) => {
@@ -77,6 +88,10 @@ const AdminJobsPage = () => {
 
   const submitUpdateCoursesByQuarterRangeJob = async (data) => {
     updateCoursesByQuarterRangeJobMutation.mutate(data);
+  };
+
+  const submitUploadGradesJob = async (data) => {
+    uploadGradesJobMutation.mutate(data);
   };
 
   // Stryker disable all
@@ -122,7 +137,11 @@ const AdminJobsPage = () => {
     },
     {
       name: "Update Grade Info",
-      form: <JobComingSoon />,
+      form: (
+        <UploadGradesJobForm
+          callback={submitUploadGradesJob}
+        />
+      ),
     },
   ];
 

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -4,8 +4,8 @@ spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
-spring.h2.console.enabled=true
-# app.showSwaggerUILink=true
+# spring.h2.console.enabled=true
+spring.h2.console.enabled=${SHOW_H2_CONSOLE_ENABLED:${env.SHOW_H2_CONSOLE_ENABLED:true}}
 
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -4,3 +4,5 @@ spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
+# app.showH2ConsoleEnabled=${SHOW_H2_CONSOLE_ENABLED:${env.SHOW_H2_CONSOLE_ENABLED:false}}
+spring.h2.console.enabled$=${SHOW_H2_CONSOLE_ENABLED:${env.SHOW_H2_CONSOLE_ENABLED:false}}


### PR DESCRIPTION
Admin can now load grade data instead of using swagger.

This completes issue Add frontend for Update Grade Data #18
which comes from EPIC #92

