### PR TITLE
fz-tabTitle

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>UCSB Course Planner</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Course Planner",
+  "name": "UCSB Course Planner",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
In this PR, I fixed the bug of displaying web title "React App" by changing it to "UCSB Course Planner"
closes #38 
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-1/assets/107012196/568c6a79-2cd1-4782-8c06-31bc86f816d7)
