### PR TITLE
en - changed course number input field to accept department names bef…

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -69,7 +69,8 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
   };
 
   const handleCourseNumberOnChange = (event) => {
-    const rawCourse = event.target.value;
+    const rawInput = event.target.value;
+    const rawCourse = rawInput.replace(/^[a-zA-Z]+/, '');
     if (rawCourse.match(/\d+/g) != null) {
       const number = rawCourse.match(/\d+/g)[0];
       setCourseNumber(number);

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -70,7 +70,7 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
 
   const handleCourseNumberOnChange = (event) => {
     const rawInput = event.target.value;
-    const rawCourse = rawInput.replace(/^[a-zA-Z]+/, '');
+    const rawCourse = rawInput.replace(/^[a-zA-Z]+/, "");
     if (rawCourse.match(/\d+/g) != null) {
       const number = rawCourse.match(/\d+/g)[0];
       setCourseNumber(number);


### PR DESCRIPTION
Fixes Issue #12 
When searching for courses on the course history page, users can enter department names with their class number. Searching for "CS156" and "156" will display the same results. Before the change, searching for "CS156" or any department name would yield no results.

Before:
<img width="1430" alt="Screenshot 2024-05-28 at 3 17 21 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-1/assets/91811005/0ccdcd57-ee94-4aad-87d8-d75a4a6ced1c">

After:
<img width="1439" alt="Screenshot 2024-05-28 at 3 36 30 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-1/assets/91811005/25b9ce90-b6a3-4df2-81da-f5477567b415">


Dokku Deployment: https://project-ericknee-dev.dokku-01.cs.ucsb.edu/courseovertime/search