### PR TITLE
fix BUG: Incorrect sorting of search output on Course History page

### DIFF
--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -19,8 +19,11 @@ export default function CourseOverTimeIndexPage() {
   });
 
   const onSuccess = (courses) => {
-    setCourseJSON(courses);
+    const sortedCourses = courses.sort((a, b) => b.courseInfo.quarter.localeCompare(a.courseInfo.quarter));
+    setCourseJSON(sortedCourses);
   };
+  
+
 
   const mutation = useBackendMutation(
     objectToAxiosParams,


### PR DESCRIPTION
In this PR, I fix the incorrect sorting by calling a sorting function, so that on the course history page, sort the results from the most recent at the top to the oldest at the bottom.
closes #45 