### PR TITLE
Add Grade History Table to Course Details Page

### DIFF
--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -5,6 +5,7 @@ import { useBackend, _useBackendMutation } from "main/utils/useBackend";
 import CourseDetailsTable from "main/components/CourseDetails/CourseDetailsTable";
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import CourseDescriptionTable from "main/components/Courses/CourseDescriptionTable";
+import GradeHistoryTable from "main/components/GradeHistory/GradeHistoryTable";
 
 export default function CourseDetailsIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -26,6 +27,25 @@ export default function CourseDetailsIndexPage() {
     },
   );
 
+  let courseId = moreDetails?.courseId || "";
+  let subject = "";
+  let course = "";
+  if (courseId) {
+    [subject, course] = courseId.split(/\s+/);
+  }
+  const { data: gradeData } = useBackend(
+    // Stryker disable all : hard to test for query caching
+    [`/api/gradehistory/search?subjectArea=${subject}&courseNumber=${course}`],
+    {
+      method: "GET",
+      url: `/api/gradehistory/search`,
+      params: {
+        subjectArea: subject,
+        courseNumber: course,
+      },
+    },
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -37,6 +57,8 @@ export default function CourseDetailsIndexPage() {
 
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}
+        {moreDetails && <h5>Grade History for {moreDetails.courseId}</h5>}
+        {gradeData && <GradeHistoryTable grades={gradeData} />}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
@@ -9,6 +9,7 @@ import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexP
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { personalSectionsFixtures } from "fixtures/personalSectionsFixtures";
+import { gradeHistoryFixtures } from "fixtures/gradeHistoryFixtures";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -56,6 +57,11 @@ describe("Course Details Index Page tests", () => {
         params: { qtr: "20221", enrollCode: "06619" },
       })
       .reply(200, personalSectionsFixtures.singleSection);
+    axiosMock
+      .onGet("/api/gradehistory/search", {
+        params: { subjectArea: "CHEM", courseNumber: "184" },
+      })
+      .reply(200, gradeHistoryFixtures.threeGrades);
   });
 
   const queryClient = new QueryClient();


### PR DESCRIPTION
In this PR, I added the grade history table component to the details page of each course.

closes #16 

<img width="1337" alt="image" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-1/assets/92133253/4de2091f-ba72-45d3-b551-00f21910127d">
