### PR TITLE
Make PersonalSchedule Form Description Optional

### DIFF
--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -84,9 +84,7 @@ function PersonalScheduleForm({
           id="description"
           type="text"
           isInvalid={Boolean(errors.description)}
-          {...register("description", {
-            required: "Description is required.",
-          })}
+          {...register("description")}
         />
         <Form.Control.Feedback type="invalid">
           {errors.description?.message}

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -5,7 +5,6 @@ import { useBackend, _useBackendMutation } from "main/utils/useBackend";
 import CourseDetailsTable from "main/components/CourseDetails/CourseDetailsTable";
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import CourseDescriptionTable from "main/components/Courses/CourseDescriptionTable";
-import GradeHistoryTable from "main/components/GradeHistory/GradeHistoryTable";
 
 export default function CourseDetailsIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -23,25 +22,6 @@ export default function CourseDetailsIndexPage() {
       params: {
         qtr,
         enrollCode,
-      },
-    },
-  );
-
-  let courseId = moreDetails?.courseId || "";
-  let subject = "";
-  let course = "";
-  if (courseId) {
-    [subject, course] = courseId.split(/\s+/);
-  }
-  const { data: gradeData } = useBackend(
-    // Stryker disable all : hard to test for query caching
-    [`/api/gradehistory/search?subjectArea=${subject}&courseNumber=${course}`],
-    {
-      method: "GET",
-      url: `/api/gradehistory/search`,
-      params: {
-        subjectArea: subject,
-        courseNumber: course,
       },
     },
   );

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -37,8 +37,6 @@ export default function CourseDetailsIndexPage() {
 
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}
-        {moreDetails && <h5>Grade History for {moreDetails.courseId}</h5>}
-        {gradeData && <GradeHistoryTable grades={gradeData} />}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -5,6 +5,7 @@ import { useBackend, _useBackendMutation } from "main/utils/useBackend";
 import CourseDetailsTable from "main/components/CourseDetails/CourseDetailsTable";
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import CourseDescriptionTable from "main/components/Courses/CourseDescriptionTable";
+import GradeHistoryTable from "main/components/GradeHistory/GradeHistoryTable";
 
 export default function CourseDetailsIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -26,6 +27,25 @@ export default function CourseDetailsIndexPage() {
     },
   );
 
+  let courseId = moreDetails?.courseId || "";
+  let subject = "";
+  let course = "";
+  if (courseId) {
+    [subject, course] = courseId.split(/\s+/);
+  }
+  const { data: gradeData } = useBackend(
+    // Stryker disable all : hard to test for query caching
+    [`/api/gradehistory/search?subjectArea=${subject}&courseNumber=${course}`],
+    {
+      method: "GET",
+      url: `/api/gradehistory/search`,
+      params: {
+        subjectArea: subject,
+        courseNumber: course,
+      },
+    },
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -37,6 +57,8 @@ export default function CourseDetailsIndexPage() {
 
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}
+        {moreDetails && <h5>Grade History for {moreDetails.courseId}</h5>}
+        {gradeData && <GradeHistoryTable grades={gradeData} />}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
@@ -10,7 +10,7 @@ export default function PersonalSchedulesCreatePage() {
     method: "POST",
     params: {
       name: personalSchedule.name,
-      description: personalSchedule.description,
+      description: personalSchedule?.description || "",
       quarter: personalSchedule.quarter,
     },
   });

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
@@ -10,7 +10,9 @@ export default function PersonalSchedulesCreatePage() {
     method: "POST",
     params: {
       name: personalSchedule.name,
-      description: personalSchedule?.description || "",
+      description: personalSchedule.description
+        ? personalSchedule.description
+        : "",
       quarter: personalSchedule.quarter,
     },
   });

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -61,7 +61,9 @@ export default function PersonalSchedulesEditPage() {
     data: {
       user: personalSchedule.user,
       name: personalSchedule.name,
-      description: personalSchedule.description,
+      description: personalSchedule.description
+        ? personalSchedule.description
+        : "",
       quarter: personalSchedule.quarter,
     },
   });

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -80,7 +80,6 @@ describe("PersonalScheduleForm tests", () => {
     fireEvent.click(submitButton);
 
     expect(await screen.findByText(/Name is required./)).toBeInTheDocument();
-    expect(screen.getByText(/Description is required./)).toBeInTheDocument();
   });
 
   test("No Error messages on good input", async () => {

--- a/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
@@ -9,6 +9,7 @@ import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexP
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { personalSectionsFixtures } from "fixtures/personalSectionsFixtures";
+import { gradeHistoryFixtures } from "fixtures/gradeHistoryFixtures";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -56,6 +57,11 @@ describe("Course Details Index Page tests", () => {
         params: { qtr: "20221", enrollCode: "06619" },
       })
       .reply(200, personalSectionsFixtures.singleSection);
+    axiosMock
+      .onGet("/api/gradehistory/search", {
+        params: { subjectArea: "CHEM", courseNumber: "184" },
+      })
+      .reply(200, gradeHistoryFixtures.threeGrades);
   });
 
   const queryClient = new QueryClient();

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
@@ -84,17 +84,14 @@ describe("PersonalSchedulesCreatePage tests", () => {
     const descriptionField = screen.getByTestId(
       "PersonalScheduleForm-description",
     );
-    //const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
     const quarterField = document.querySelector(
       "#PersonalScheduleForm-quarter",
     );
-    //const selectQuarter = getByLabelText("Quarter")
     const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
     fireEvent.change(nameField, { target: { value: "SampName" } });
     fireEvent.change(descriptionField, { target: { value: "desc" } });
     fireEvent.change(quarterField, { target: { value: "20124" } });
-    //userEvent.selectOptions(selectQuarter, "20124");
 
     expect(submitButton).toBeInTheDocument();
 
@@ -103,7 +100,6 @@ describe("PersonalSchedulesCreatePage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
     expect(quarterField).toHaveValue("20124");
-    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
 
     expect(axiosMock.history.post[0].params).toEqual({
       name: "SampName",
@@ -158,7 +154,6 @@ describe("PersonalSchedulesCreatePage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
     expect(quarterField).toHaveValue("20124");
-    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
 
     expect(axiosMock.history.post[0].params).toEqual({
       name: "Duplicate",
@@ -169,7 +164,6 @@ describe("PersonalSchedulesCreatePage tests", () => {
     expect(mockToast).toBeCalledWith(
       "Error: A personal schedule with that name already exists in that quarter",
     );
-    // expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
   });
   test("filling the form with no description gives no error", async () => {
     const queryClient = new QueryClient();
@@ -196,16 +190,13 @@ describe("PersonalSchedulesCreatePage tests", () => {
     ).toBeInTheDocument();
 
     const nameField = screen.getByTestId("PersonalScheduleForm-name");
-    //const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
     const quarterField = document.querySelector(
       "#PersonalScheduleForm-quarter",
     );
-    //const selectQuarter = getByLabelText("Quarter")
     const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
     fireEvent.change(nameField, { target: { value: "SampName" } });
     fireEvent.change(quarterField, { target: { value: "20124" } });
-    //userEvent.selectOptions(selectQuarter, "20124");
 
     expect(submitButton).toBeInTheDocument();
 
@@ -214,7 +205,6 @@ describe("PersonalSchedulesCreatePage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
     expect(quarterField).toHaveValue("20124");
-    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
 
     expect(axiosMock.history.post[0].params).toEqual({
       name: "SampName",

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
@@ -171,4 +171,60 @@ describe("PersonalSchedulesCreatePage tests", () => {
     );
     // expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
   });
+  test("filling the form with no description gives no error", async () => {
+    const queryClient = new QueryClient();
+    const personalSchedule = {
+      id: 17,
+      name: "SampName",
+      quarter: "W08",
+    };
+
+    axiosMock
+      .onPost("/api/personalschedules/post")
+      .reply(202, personalSchedule);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSchedulesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId("PersonalScheduleForm-name"),
+    ).toBeInTheDocument();
+
+    const nameField = screen.getByTestId("PersonalScheduleForm-name");
+    //const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
+    const quarterField = document.querySelector(
+      "#PersonalScheduleForm-quarter",
+    );
+    //const selectQuarter = getByLabelText("Quarter")
+    const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+    fireEvent.change(nameField, { target: { value: "SampName" } });
+    fireEvent.change(quarterField, { target: { value: "20124" } });
+    //userEvent.selectOptions(selectQuarter, "20124");
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(quarterField).toHaveValue("20124");
+    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      name: "SampName",
+      description: "",
+      quarter: "20124",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New personalSchedule Created - id: 17 name: SampName",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
+  });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -367,6 +367,6 @@ describe("PersonalSchedulesEditPage tests", () => {
           quarter: "20221",
         }),
       ); // posted object
-    })
+    });
   });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -298,5 +298,75 @@ describe("PersonalSchedulesEditPage tests", () => {
         screen.queryByTestId(`${testId}-cell-row-0-col-id`),
       ).not.toBeInTheDocument();
     });
+    test("updates correctly without description", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("PersonalScheduleForm-id");
+
+      const idField = screen.getByTestId("PersonalScheduleForm-id");
+      const nameField = screen.getByTestId("PersonalScheduleForm-name");
+      const descriptionField = screen.getByTestId(
+        "PersonalScheduleForm-description",
+      );
+      const quarterField = screen.getByTestId("PersonalScheduleForm-quarter");
+      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+
+      expect(nameField).toBeInTheDocument();
+      expect(nameField).toHaveValue("CS156");
+
+      expect(descriptionField).toBeInTheDocument();
+      expect(descriptionField).toHaveValue("My Winter Courses");
+
+      expect(quarterField).toBeInTheDocument();
+
+      expect(quarterField).toHaveValue("W22");
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(nameField, { target: { value: "Winter Courses" } });
+      fireEvent.change(descriptionField, {
+        target: { value: "" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "PersonalSchedule Updated - id: 17 name: Winter Courses",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          name: "Winter Courses",
+          description: "",
+          quarter: "20221",
+        }),
+      ); // posted object
+    })
   });
 });


### PR DESCRIPTION
In this PR, I made the personal schedule form more user friendly by making the description field optional. Also added full test coverage.
Closes #51 

In the gif below, I demonstrate the new personal schedule form. As you can see the add form no longer requires a description and the personal schedule index page correctly displays the new schedule with no description. Similarly, the edit form doesn't require a description
![Screen Recording 2024-05-29 at 6 08 33 PM](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-1/assets/92133253/cbcb28cb-4444-4438-93bf-68515a7cd320)

