### PR TITLE
Ruizhe - Add frontend part of delete button feature for personal sections table

### DIFF
--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -11,7 +11,11 @@ import {
 } from "main/utils/sectionUtils.js";
 import { hasRole } from "main/utils/currentUser";
 
-export default function PersonalSectionsTable({ personalSections,currentUser,psId,}) {
+export default function PersonalSectionsTable({
+  personalSections,
+  currentUser,
+  psId,
+}) {
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
@@ -75,7 +79,9 @@ export default function PersonalSectionsTable({ personalSections,currentUser,psI
 
   const testid = "PersonalSectionsTable";
 
-  const columnsToDisplay = hasRole(currentUser, "ROLE_USER")?columnsWithDelete:columns;
+  const columnsToDisplay = hasRole(currentUser, "ROLE_USER")
+    ? columnsWithDelete
+    : columns;
   return (
     <OurTable
       data={personalSections}

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -16,11 +16,14 @@ export default function PersonalSectionsTable({
   currentUser,
   psId,
 }) {
+  // Stryker disable all : hard to test for query caching
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
+    //["/api/personalSections/delete"],
     [],
   );
+  // Stryker restore all
   const deleteCallback = async (cell) => {
     deleteMutation.mutate({ cell, psId });
   };
@@ -79,9 +82,7 @@ export default function PersonalSectionsTable({
 
   const testid = "PersonalSectionsTable";
 
-  const columnsToDisplay = hasRole(currentUser, "ROLE_USER")
-    ? columnsWithDelete
-    : columns;
+  const columnsToDisplay = hasRole(currentUser,"ROLE_USER")?columnsWithDelete:columns;
   return (
     <OurTable
       data={personalSections}

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -1,13 +1,26 @@
 import React from "react";
-import OurTable from "main/components/OurTable";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
 import {
   convertToFraction,
   formatInstructors,
   formatLocation,
   formatTime,
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
 } from "main/utils/sectionUtils.js";
+import { hasRole } from "main/utils/currentUser";
 
-export default function PersonalSectionsTable({ personalSections }) {
+export default function PersonalSectionsTable({ personalSections,currentUser,psId,}) {
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    [],
+  );
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate({ cell, psId });
+  };
+
   const columns = [
     {
       Header: "Course ID",
@@ -55,10 +68,14 @@ export default function PersonalSectionsTable({ personalSections }) {
     },
   ];
 
+  const columnsWithDelete = [
+    ...columns,
+    ButtonColumn("Delete", "danger", deleteCallback, "PersonalSectionsTable"),
+  ];
+
   const testid = "PersonalSectionsTable";
 
-  const columnsToDisplay = columns;
-
+  const columnsToDisplay = hasRole(currentUser, "ROLE_USER")?columnsWithDelete:columns;
   return (
     <OurTable
       data={personalSections}

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -82,7 +82,9 @@ export default function PersonalSectionsTable({
 
   const testid = "PersonalSectionsTable";
 
-  const columnsToDisplay = hasRole(currentUser,"ROLE_USER")?columnsWithDelete:columns;
+  const columnsToDisplay = hasRole(currentUser, "ROLE_USER")
+    ? columnsWithDelete
+    : columns;
   return (
     <OurTable
       data={personalSections}

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -4,9 +4,11 @@ import PersonalSchedulesTable from "main/components/PersonalSchedules/PersonalSc
 import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
 import { useBackend, _useBackendMutation } from "main/utils/useBackend";
 import { Button } from "react-bootstrap";
+import { useCurrentUser } from "main/utils/currentUser";
 
 export default function PersonalSchedulesDetailsPage() {
   let { id } = useParams();
+  const currentUser = useCurrentUser();
 
   const {
     data: personalSchedule,
@@ -57,7 +59,11 @@ export default function PersonalSchedulesDetailsPage() {
         <p>
           <h2>Sections in Personal Schedule</h2>
           {personalSection && (
-            <PersonalSectionsTable personalSections={personalSection} />
+            <PersonalSectionsTable
+              personalSections={personalSection}
+              currentUser={currentUser}
+              psId={id}
+            />
           )}
         </p>
         {createButton()}

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -1,4 +1,5 @@
 import { hhmmTohhmma, convertToTimeRange } from "main/utils/timeUtils.js";
+import { toast } from "react-toastify";
 
 export const convertToFraction = (en1, en2) => {
   return en1 != null && en2 != null ? `${en1}/${en2}` : "";
@@ -104,3 +105,20 @@ export const renderInfoLink = ({ cell: { value } }) => (
     </a>
   </p>
 );
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete({cell, psId}) {
+  const enrollCode = cell.row.values["classSections[0].enrollCode"];
+  return {
+    url: "/api/personalSections/delete",
+    method: "DELETE",
+    params: {
+      psId: psId,
+      enrollCd: enrollCode,
+    },
+  };
+}

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -112,6 +112,7 @@ export function onDeleteSuccess(message) {
 }
 
 export function cellToAxiosParamsDelete({cell, psId}) {
+  console.log(cell);
   const enrollCode = cell.row.values["classSections[0].enrollCode"];
   return {
     url: "/api/personalSections/delete",

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -111,7 +111,7 @@ export function onDeleteSuccess(message) {
   toast(message);
 }
 
-export function cellToAxiosParamsDelete({cell, psId}) {
+export function cellToAxiosParamsDelete({ cell, psId }) {
   console.log(cell);
   const enrollCode = cell.row.values["classSections[0].enrollCode"];
   return {

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -171,7 +171,7 @@ describe("PersonalSectionsTable tests", () => {
     expect(deleteButton).toHaveClass("btn-danger");
 
     fireEvent.click(deleteButton);
-    
+
     await waitFor(() =>
       expect(mockedMutate).toHaveBeenCalledWith({
         cell: expect.any(Object),

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -20,7 +20,7 @@ jest.mock("main/utils/useBackend", () => ({
   useBackendMutation: () => ({ mutate: mockedMutate }),
 }));
 
-describe("UserTable tests", () => {
+describe("PersonalSectionsTable tests", () => {
   const queryClient = new QueryClient();
 
   test("renders without crashing for empty table with user not logged in", () => {
@@ -146,5 +146,36 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-instructor`),
     ).toHaveTextContent("STEPHANSON B, BUCKWALTER J");
+  });
+
+  test("Delete button calls delete callback for user", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+    const psId = 1;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSectionsTable
+            personalSections={personalSectionsFixtures.threePersonalSections}
+            currentUser={currentUser}
+            psId={psId}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const deleteButton = screen.getByTestId(
+      `PersonalSectionsTable-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() =>
+      expect(mockedMutate).toHaveBeenCalledWith({
+        cell: expect.any(Object),
+        psId,
+      }),
+    );
   });
 });

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -168,9 +168,10 @@ describe("PersonalSectionsTable tests", () => {
       `PersonalSectionsTable-cell-row-0-col-Delete-button`,
     );
     expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
 
     fireEvent.click(deleteButton);
-
+    
     await waitFor(() =>
       expect(mockedMutate).toHaveBeenCalledWith({
         cell: expect.any(Object),

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -159,11 +159,13 @@ describe("section utils tests", () => {
   describe("cellToAxiosParamsDelete", () => {
     test("It returns the correct params", () => {
       // arrange
-      const cell = { row: { values: { "classSections[0].enrollCode": "80300"} } };
+      const cell = {
+        row: { values: { "classSections[0].enrollCode": "80300" } },
+      };
       const psId = 1;
-      
+
       // act
-      const result = cellToAxiosParamsDelete({cell, psId});
+      const result = cellToAxiosParamsDelete({ cell, psId });
 
       // assert
       expect(result).toEqual({

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -1,3 +1,5 @@
+import mockConsole from "jest-mock-console";
+import { toast } from "react-toastify";
 import {
   convertToFraction,
   formatLocation,
@@ -7,8 +9,19 @@ import {
   formatInstructors,
   formatInfoLink,
   renderInfoLink,
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
 } from "main/utils/sectionUtils";
 import { oneSection } from "../../fixtures/sectionFixtures";
+
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: jest.fn(),
+  };
+});
 
 const testTimeLocations = [
   {
@@ -123,5 +136,52 @@ describe("section utils tests", () => {
     });
     expect(view.props.children.props.style.color).toBe("white");
     expect(view.props.children.props.href).toBe("/coursedetails/20221/12583");
+  });
+
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(toast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      //const cell = { row: { values: { "classSections[0].enrollCode": "80300"} } };
+      const psId = 1;
+      const cell = {
+        row: {
+          values: {
+            "classSections[0].enrollCode": "80300",
+          },
+        },
+      };
+      
+
+      // act
+      const result = cellToAxiosParamsDelete(cell, psId);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/personalSections/delete",
+        method: "DELETE",
+        params: {
+          psId: psId,
+          enrollCd: "80300",
+        },
+      });
+    });
   });
 });

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -159,19 +159,11 @@ describe("section utils tests", () => {
   describe("cellToAxiosParamsDelete", () => {
     test("It returns the correct params", () => {
       // arrange
-      //const cell = { row: { values: { "classSections[0].enrollCode": "80300"} } };
+      const cell = { row: { values: { "classSections[0].enrollCode": "80300"} } };
       const psId = 1;
-      const cell = {
-        row: {
-          values: {
-            "classSections[0].enrollCode": "80300",
-          },
-        },
-      };
       
-
       // act
-      const result = cellToAxiosParamsDelete(cell, psId);
+      const result = cellToAxiosParamsDelete({cell, psId});
 
       // assert
       expect(result).toEqual({


### PR DESCRIPTION
In this PR, I add the frontend part of delete button for personal sections table.
closed #15 
Deployment link https://proj-ruizhejiang-dev.dokku-01.cs.ucsb.edu/
The button can be used as following pictures.
Steps:
1. Login to an google account.
2. Create a personal schedule.
3. Add courses to the schedule.
4. Go to the personal schedule detail page and click on the delete button, and the chosen course will be dropped together with affiliated lectures and sections.

An example is showed below.
Before clicking delete:
![1717105216939](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-1/assets/129798130/b7d1e6a1-0ff9-4904-a3a1-5cee6871eb28)
After clicking delete:
![1717105236192](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-1/assets/129798130/4bfa2ff1-dc17-4b48-a713-8af4276e7526)
